### PR TITLE
Fix: Refine request interceptor for MFA

### DIFF
--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -44,6 +44,13 @@ export const requestConfig: RequestConfig = {
             NoLoginedHandler();
             message.info('登录已过期. 请重新登录.');
           }
+        } else if (
+          error.response.status === 403 &&
+          error.response.data?.message === 'MFA_REQUIRED'
+        ) {
+          NoLoginedHandler();
+          history.push(loginPath);
+          message.warning('该操作需要多因素认证，请重新登录。');
         } else {
           message.error(error.response.data?.message || '请求失败');
         }

--- a/src/models/request.ts
+++ b/src/models/request.ts
@@ -61,31 +61,59 @@ export const requestConfig: RequestConfig = {
   },
   requestInterceptors: [
     async (url: string, options: any) => {
-      // 非鉴权接口
-      const isLoginRequest =
-        url.includes('/login') || url.includes('/token/refresh');
-      if (isLoginRequest) {
+      console.log(`[Request Interceptor] Request URL: ${url}`);
+      // 精确匹配：只有初次登录和刷新 Token 不需要带 Authorization
+      const isInitialLogin = url === '/api/login';
+      const isTokenRefresh = url.includes('/token/refresh');
+
+      if (isInitialLogin || isTokenRefresh) {
+        console.log(`[Request Interceptor] Skipping Auth header for: ${url}`);
         return { url, options };
       }
 
       let access = true;
+      const accessToken = getLocalAccessToken();
+      console.log(
+        `[Request Interceptor] Local AccessToken found: ${
+          accessToken ? 'Yes' : 'No'
+        }`,
+      );
+
       if (!isLogined()) {
+        console.log('[Request Interceptor] Not logined, attempting refresh...');
         // refresh token 也要过期的 token 判断是否同一用户
-        const accessToken = getLocalAccessToken();
-        options.headers.Authorization = `Bearer ${accessToken}`;
-        const response = await tokenRefresh(options);
-        if (response.code === 200) {
-          LoginHandler(parseAccessToken(response.data.accessToken));
+        if (accessToken) {
+          options.headers.Authorization = `Bearer ${accessToken}`;
+          try {
+            const response = await tokenRefresh(options);
+            if (response.code === 200) {
+              console.log('[Request Interceptor] Token refresh success');
+              LoginHandler(parseAccessToken(response.data.accessToken));
+            } else {
+              access = false;
+            }
+          } catch (e) {
+            console.error('[Request Interceptor] Token refresh failed', e);
+            access = false;
+          }
         } else {
           access = false;
         }
       }
-      // refresh token 之后, 确保拿到的是最新的 token.
-      const accessToken = getLocalAccessToken();
-      options.headers.Authorization = `Bearer ${accessToken}`;
+
+      // 重新获取最新的 token
+      const latestToken = getLocalAccessToken();
+      if (latestToken) {
+        options.headers.Authorization = `Bearer ${latestToken}`;
+        console.log(
+          `[Request Interceptor] Added Authorization header for: ${url}`,
+        );
+      }
 
       if (!access) {
-        console.log(`cancel request ${url}`);
+        console.warn(
+          `[Request Interceptor] Access denied for ${url}, redirecting...`,
+        );
         return new Promise(() => {});
       }
       return { url, options };

--- a/src/pages/Login/components/MFAModal.tsx
+++ b/src/pages/Login/components/MFAModal.tsx
@@ -21,7 +21,6 @@ const MFAModal: React.FC<MFAModalProps> = ({
     try {
       const response = await verifyMFA(values);
       if (response.code === 200 && response.data?.accessToken) {
-        message.success('验证成功');
         onSuccess(response.data.accessToken);
         form.resetFields();
       } else {

--- a/src/pages/Login/components/MFAModal.tsx
+++ b/src/pages/Login/components/MFAModal.tsx
@@ -1,0 +1,63 @@
+import { verifyMFA } from '@/services/demo/loginController';
+import { Form, Input, Modal, message } from 'antd';
+import React, { useState } from 'react';
+
+interface MFAModalProps {
+  visible: boolean;
+  onCancel: () => void;
+  onSuccess: (accessToken: string) => void;
+}
+
+const MFAModal: React.FC<MFAModalProps> = ({
+  visible,
+  onCancel,
+  onSuccess,
+}) => {
+  const [form] = Form.useForm();
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (values: { code: string }) => {
+    setLoading(true);
+    try {
+      const response = await verifyMFA(values);
+      if (response.code === 200 && response.data?.accessToken) {
+        message.success('验证成功');
+        onSuccess(response.data.accessToken);
+        form.resetFields();
+      } else {
+        message.error(response.message || '验证失败');
+      }
+    } catch (error: any) {
+      // Error is handled by errorHandler, but we need to stop loading
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      title="多因素认证 (MFA)"
+      open={visible}
+      onCancel={onCancel}
+      onOk={() => form.submit()}
+      confirmLoading={loading}
+      destroyOnClose
+    >
+      <p>请输入 TOTP 验证码以继续登录。</p>
+      <Form form={form} onFinish={handleSubmit} layout="vertical">
+        <Form.Item
+          name="code"
+          label="验证码"
+          rules={[
+            { required: true, message: '请输入 6 位验证码' },
+            { len: 6, message: '请输入 6 位数字' },
+          ]}
+        >
+          <Input placeholder="000000" maxLength={6} autoFocus />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default MFAModal;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -3,10 +3,12 @@ import { isLogined, LoginHandler, parseAccessToken } from '@/utils/auth';
 import { Button, Form, Input, message } from 'antd';
 import React, { useEffect, useState } from 'react';
 import { history, useModel } from 'umi';
+import MFAModal from './components/MFAModal';
 
 const LoginPage: React.FC = () => {
   const { refresh } = useModel('@@initialState');
   const [loading, setLoading] = useState(false);
+  const [isMFAModalVisible, setIsMFAModalVisible] = useState(false);
 
   useEffect(() => {
     if (isLogined()) {
@@ -19,13 +21,29 @@ const LoginPage: React.FC = () => {
     setLoading(true);
     try {
       const response = await login(req);
-      LoginHandler(parseAccessToken(response.data.accessToken));
-      await refresh();
-      message.success('登录成功');
-      history.push('/home');
+      const { accessToken, mfa_required } = response.data || {};
+
+      if (mfa_required) {
+        // 保存受限 Token
+        LoginHandler(parseAccessToken(accessToken!));
+        setIsMFAModalVisible(true);
+      } else {
+        LoginHandler(parseAccessToken(accessToken!));
+        await refresh();
+        message.success('登录成功');
+        history.push('/home');
+      }
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleMFASuccess = async (fullToken: string) => {
+    setIsMFAModalVisible(false);
+    LoginHandler(parseAccessToken(fullToken));
+    await refresh();
+    message.success('验证成功');
+    history.push('/home');
   };
 
   return (
@@ -49,6 +67,11 @@ const LoginPage: React.FC = () => {
           </Button>
         </Form.Item>
       </Form>
+      <MFAModal
+        visible={isMFAModalVisible}
+        onCancel={() => setIsMFAModalVisible(false)}
+        onSuccess={handleMFASuccess}
+      />
     </div>
   );
 };

--- a/src/services/demo/loginController.ts
+++ b/src/services/demo/loginController.ts
@@ -35,3 +35,21 @@ export async function tokenRefresh(options?: { [key: string]: any }) {
     },
   );
 }
+
+/** MFA 验证 POST /login/mfa-verify */
+export async function verifyMFA(
+  body: API.MFAVerifyRequest,
+  options?: { [key: string]: any },
+) {
+  return request<API.AppRes & { data?: API.LoginResponse }>(
+    `/api/login/mfa-verify`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      data: body,
+      ...(options || {}),
+    },
+  );
+}

--- a/src/services/demo/typings.d.ts
+++ b/src/services/demo/typings.d.ts
@@ -31,6 +31,15 @@ declare namespace API {
   type LoginResponse = {
     /** JWT 访问令牌 */
     accessToken?: string;
+    /** MFA 是否必要 */
+    mfa_required?: boolean;
+    /** MFA 类型列表 */
+    required_types?: string[];
+  };
+
+  type MFAVerifyRequest = {
+    /** TOTP 验证码 */
+    code: string;
   };
 
   type LotteryResult = {


### PR DESCRIPTION
This PR fixes a bug where the request interceptor was skipping the Authorization header for MFA verification requests because it matched '/login'. It now precisely matches the initial login path.